### PR TITLE
Change Android Package Name to "ch.procivis.systime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 #### Android
 
 1. Open up `android/app/src/main/java/[...]/MainActivity.java`
-  - Add `import com.reactlibrary.RNSystemtimePackage;` to the imports at the top of the file
+  - Add `import ch.procivis.systime.RNSystemtimePackage;` to the imports at the top of the file
   - Add `new RNSystemtimePackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
   	```

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="ch.procivis.systime">
 
 </manifest>
   

--- a/android/src/main/java/ch/procivis/systime/RNSystemtimeModule.java
+++ b/android/src/main/java/ch/procivis/systime/RNSystemtimeModule.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package ch.procivis.systime;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;

--- a/android/src/main/java/ch/procivis/systime/RNSystemtimePackage.java
+++ b/android/src/main/java/ch/procivis/systime/RNSystemtimePackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package ch.procivis.systime;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Previously it was using the default name, which might lead to conflicts with
other libraries that didn't bother to introduce a custom package name.